### PR TITLE
Implement Hybrid Ingress (Tailscale Mesh + LAN-Only HTTPS Fallback)

### DIFF
--- a/SECURITY_ARCHITECTURE.md
+++ b/SECURITY_ARCHITECTURE.md
@@ -41,7 +41,13 @@ To prevent network configuration corruption during container startup, the OSH Ba
 The OSCAR architecture relies on a PEM-first cryptographic foundation managed completely within the Docker deployment ecosystem.
 - **Dynamic Runtime Generation**: Instead of baking SSL certificates into public Docker images or relying on proprietary Java generators, the `init-secrets` ephemeral container automatically generates standard OpenSSL PEM certificates (`ca.pem`, `server.pem`) upon the very first system boot.
 - **Java Compatibility**: To satisfy the OpenSensorHub Java backend's `SSLContext` requirements without modifying core OSH code, the `init-secrets` container dynamically bundles the raw PEM files into PKCS12 (`osh-keystore.p12`) and JKS (`truststore.jks`) vaults using `openssl pkcs12` and `keytool`. These are distributed securely to the backend via the `oscar_secrets` named volume.
-- **Caddy Reverse Proxy TLS**: The Caddy proxy (which manages all external ingress) natively consumes the raw `server.pem` and `server.key` from the same shared volume, guaranteeing the entire stack uses the exact same unified cryptographic trust chain.
+- **Caddy Reverse Proxy TLS**: The Caddy proxy manages all external ingress. In **Federated/Mesh mode**, it utilizes Tailscale's native integration to fetch Let's Encrypt certificates. In **Local/LAN mode**, it natively consumes the raw `server.pem` and `server.key` from the shared `oscar_secrets` volume, guaranteeing the entire stack uses the exact same unified cryptographic trust chain for direct LAN access.
+
+### Hybrid Ingress Security (Caddy Firewall)
+The system implements strict firewalling at the proxy level to prevent unauthorized access over the LAN:
+- **HTTP (Port 80)**: Only requests originating from `localhost` (127.0.0.1 / ::1) are permitted. All other HTTP traffic is aborted.
+- **LAN HTTPS (Port 443)**: Only requests originating from private IP ranges (RFC 1918) or `localhost` are permitted. This ensures that even if port 443 is exposed to a public network, only local devices can establish a TLS session using the internal CA.
+- **Tailscale Mesh**: Ingress via the Tailscale MagicDNS name bypasses these LAN restrictions, as it is routed through the authenticated Tailscale tunnel and terminated separately in Caddy.
 - **Fail-Secure Inheritance**: The backend's startup scripts (`launch.sh` / `launch.bat`) strictly rely on the Docker Compose `KEYSTORE_PASSWORD_FILE` environment variables. If the `.app_secrets` file is missing, the application will halt with a critical error rather than falling back to unsafe default passwords.
 - **Public CA Download**: The public Root CA certificate is available for download at `/sensorhub/admin/ca-cert` to allow clients to establish trust.
 

--- a/SECURITY_ARCHITECTURE.md
+++ b/SECURITY_ARCHITECTURE.md
@@ -44,10 +44,14 @@ The OSCAR architecture relies on a PEM-first cryptographic foundation managed co
 - **Caddy Reverse Proxy TLS**: The Caddy proxy manages all external ingress. In **Federated/Mesh mode**, it utilizes Tailscale's native integration to fetch Let's Encrypt certificates. In **Local/LAN mode**, it natively consumes the raw `server.pem` and `server.key` from the shared `oscar_secrets` volume, guaranteeing the entire stack uses the exact same unified cryptographic trust chain for direct LAN access.
 
 ### Hybrid Ingress Security (Caddy Firewall)
-The system implements strict firewalling at the proxy level to prevent unauthorized access over the LAN:
-- **HTTP (Port 80)**: Only requests originating from `localhost` (127.0.0.1 / ::1) are permitted. All other HTTP traffic is aborted.
-- **LAN HTTPS (Port 443)**: Only requests originating from private IP ranges (RFC 1918) or `localhost` are permitted. This ensures that even if port 443 is exposed to a public network, only local devices can establish a TLS session using the internal CA.
-- **Tailscale Mesh**: Ingress via the Tailscale MagicDNS name bypasses these LAN restrictions, as it is routed through the authenticated Tailscale tunnel and terminated separately in Caddy.
+The system implements strict firewalling at the proxy level and utilizes Docker Compose profiles to ensure isolation:
+- **Profiles**:
+  - `mesh`: The proxy runs inside the Tailscale network namespace (`network_mode: "service:tailscale"`). This is the recommended mode for secure remote access.
+  - `lan-only`: The proxy runs on the standard bridge network and binds ports directly to the host. This mode is used for airgapped or LAN-only deployments where Tailscale is unavailable.
+- **Firewall Rules**:
+  - **HTTP (Port 80)**: Only requests originating from `localhost` (127.0.0.1 / ::1) are permitted. All other HTTP traffic is aborted.
+  - **LAN HTTPS (Port 443)**: Only requests originating from private IP ranges (RFC 1918), CGNAT ranges (Tailscale), or `localhost` are permitted. This ensures that even if port 443 is exposed to a public network, only local or mesh devices can establish a TLS session using the internal CA.
+  - **Tailscale Mesh**: Ingress via the Tailscale MagicDNS name bypasses these LAN restrictions, as it is terminated separately in Caddy.
 - **Fail-Secure Inheritance**: The backend's startup scripts (`launch.sh` / `launch.bat`) strictly rely on the Docker Compose `KEYSTORE_PASSWORD_FILE` environment variables. If the `.app_secrets` file is missing, the application will halt with a critical error rather than falling back to unsafe default passwords.
 - **Public CA Download**: The public Root CA certificate is available for download at `/sensorhub/admin/ca-cert` to allow clients to establish trust.
 

--- a/SYSTEM_ARCHITECTURE.md
+++ b/SYSTEM_ARCHITECTURE.md
@@ -59,9 +59,15 @@ OSCAR is designed to scale from edge devices to enterprise environments. You can
 ### Main Launch Commands:
 The stack is fully containerized using Docker Compose. Official Docker images (`oscar-backend`, `oscar-postgis`) are published to Docker Hub for every release.
 
+The system supports two primary networking profiles:
+1. **Mesh Mode (Default)**: Uses Tailscale for secure remote access.
+   - `docker compose --profile mesh up -d`
+2. **LAN-Only Mode (Airgapped)**: Disables Tailscale and binds proxy ports directly to the host for local network access.
+   - `docker compose --profile lan-only up -d`
+
 There are two ways to launch the stack:
-- **Online (Docker Hub)**: Download the `docker-compose.yml` and `.env.example` from the latest release and run `docker compose up -d`. This will automatically pull the pre-built images.
-- **Offline (Source)**: Extract the full `.zip` release artifact containing the Dockerfiles and run `docker compose up -d` from the root directory to build the images locally. Launch scripts in `dist/release/` (e.g., `launch-all.sh`, `launch-all.bat`) are provided for backward compatibility.
+- **Online (Docker Hub)**: Download the `docker-compose.yml` and `.env.example` from the latest release and run `docker compose --profile mesh up -d`. This will automatically pull the pre-built images.
+- **Offline (Source)**: Extract the full `.zip` release artifact containing the Dockerfiles and run `docker compose --profile lan-only up -d` from the root directory to build the images locally. Launch scripts in `dist/release/` (e.g., `launch-all.sh`, `launch-all.bat`) are provided for backward compatibility.
 
 ### Distributed Enterprise Deployment (Scenario C)
 To deploy the Enterprise Central Hub profile, you must split the components across two distinct machines on the same local network (LAN). **Important Initialization Logic**: The system relies on a unified, randomly generated database password. Because the application and database will be on separate machines, you must manually sync this secret.

--- a/SYSTEM_ARCHITECTURE.md
+++ b/SYSTEM_ARCHITECTURE.md
@@ -35,7 +35,7 @@ OSCAR is designed to scale from edge devices to enterprise environments. You can
    *   **Setup**: Separates the database from the application backend over a high-speed LAN connection. See Deployment instructions below. **Native Ubuntu Deployments**: For high-density UDP streaming, Linux launch scripts automatically apply `sysctl` kernel tuning (UDP buffers, file limits) and `ufw` firewall rules to permit containerized backend communication with the host MediaMTX proxy (port 9997). Additionally, FFmpeg sensors utilize authenticated RTSP connection strings to communicate with the host-bound MediaMTX proxy.
 
 ### Default Port Configuration:
-- **Caddy Reverse Proxy (within Tailscale namespace)**: Operates entirely inside the sidecar's networking context. It does not map ports to the host file directly, but dynamically secures ports `80` (HTTP) and `443` (HTTPS) over the mesh.
+- **Caddy Reverse Proxy (within Tailscale namespace)**: Operates entirely inside the sidecar's networking context. It maps ports `80` and `443` to the host to allow direct LAN ingress while maintaining the primary Tailscale mesh.
 - **OSH Backend API (HTTP)**: `8282` (Bound to `127.0.0.1` locally, accessible externally via proxy)
 - **OSH Backend Admin UI**: `8282` (Bound to `127.0.0.1` locally, accessible externally via proxy)
 - **PostGIS Database**: `5432` (Internal Docker Network only)
@@ -44,7 +44,10 @@ OSCAR is designed to scale from edge devices to enterprise environments. You can
 - **MediaMTX RTSP Server**: `8554` (Bound to host, intercepts camera streams)
 
 ### Network Flows:
-- **Client to OSH**: Clients interact with OSH through its REST API and Web UI via the reverse proxy on ports `80` or `443` (or port `8282` locally). The client is now progressive web app (PWA) compatible and can be installed locally via a modern web browser.
+- **Client to OSH**: Clients interact with OSH through its REST API and Web UI via the reverse proxy on ports `80` or `443`. The system supports **Hybrid Ingress**:
+  - **Tailscale Mesh**: Secure access via MagicDNS using Let's Encrypt certificates managed by Tailscale.
+  - **LAN HTTPS Fallback**: Direct access over the local network using the dynamically generated Root CA and Server certificates.
+  - **Localhost HTTP**: Plain HTTP access is strictly limited to the local machine (`127.0.0.1`).
 - **Client Features**: The progressive web application contains specialized functionality such as offline caching, client-side WebID analysis, and camera integration for Spectroscopic QR Code scanning during Adjudication workflows. New in v3.3.1 is an enhanced evidence tracking system that allows for asynchronous WebID analysis submission and persistence of multiple adjudications per occupancy.
 - **OSH to PostGIS**: The OSH backend connects to the PostGIS database over the network (local or LAN) on port `5432`. This connection is secured via TLS and authenticated with SCRAM-SHA-256.
 - **MQTT Connectivity**: The system maintains stable MQTT connections over WebSockets. Both the OSH backend and the reverse proxy are configured with an increased 10-minute idle timeout to prevent frequent disconnections in high-latency environments (e.g., Tailscale mesh). Additionally, the frontend MQTT client implements a proactive 15-second keepalive interval to ensure the connection remains active during periods of telemetry inactivity.

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
+- **Hybrid Ingress Support**: Implemented a resilient dual-ingress proxy architecture. The system now supports secure direct HTTPS access over the Local Area Network (LAN) using dynamically generated PEM certificates, while maintaining the primary Tailscale mesh.
 - Added Progressive Web App (PWA) capabilities, allowing the client to be installed as a local application with offline support.
 - Integrated Spectroscopic QR Code scanning for Adjudication workflows.
 - Added WebID analysis and result logging to the Adjudication Detail view.

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
-- **Hybrid Ingress Support**: Implemented a resilient dual-ingress proxy architecture. The system now supports secure direct HTTPS access over the Local Area Network (LAN) using dynamically generated PEM certificates, while maintaining the primary Tailscale mesh.
+- **Hybrid Ingress Support**: Implemented a resilient dual-ingress proxy architecture using Docker Compose profiles (`mesh` and `lan-only`). The system now supports secure direct HTTPS access over the Local Area Network (LAN) using dynamically generated PEM certificates, while maintaining the primary Tailscale mesh.
 - Added Progressive Web App (PWA) capabilities, allowing the client to be installed as a local application with offline support.
 - Integrated Spectroscopic QR Code scanning for Adjudication workflows.
 - Added WebID analysis and result logging to the Adjudication Detail view.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,6 +197,7 @@ services:
     image: tailscale/tailscale:v1.96.5
     container_name: oscar-tailscale
     hostname: ${NODE_NAME:-oscar-server}
+    profiles: ["mesh"]
     environment:
       - TS_AUTHKEY=${TS_AUTHKEY}
       - TS_ROUTES=${TS_ROUTES:-}
@@ -217,9 +218,10 @@ services:
       - sys_module
     restart: unless-stopped
 
-  osh-proxy:
+  osh-proxy-mesh:
     image: caddy:2.9.1
     container_name: oscar-proxy
+    profiles: ["mesh"]
     network_mode: "service:tailscale"
     depends_on:
       tailscale:
@@ -233,6 +235,63 @@ services:
       - caddy_data:/data
       - caddy_config:/config
       - ./tailscale/sock:/var/run/tailscale:ro
+      - oscar_secrets:/etc/caddy/certs:ro
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    command:
+      - /bin/sh
+      - -c
+      - |
+        echo ":80 {" > /etc/caddy/Caddyfile
+        echo "    @not_localhost {" >> /etc/caddy/Caddyfile
+        echo "        not remote_ip 127.0.0.1 ::1" >> /etc/caddy/Caddyfile
+        echo "    }" >> /etc/caddy/Caddyfile
+        echo "    abort @not_localhost" >> /etc/caddy/Caddyfile
+        echo "    reverse_proxy http://osh-backend:8282 {" >> /etc/caddy/Caddyfile
+        echo "        flush_interval -1" >> /etc/caddy/Caddyfile
+        echo "    }" >> /etc/caddy/Caddyfile
+        echo "}" >> /etc/caddy/Caddyfile
+        echo ":443 {" >> /etc/caddy/Caddyfile
+        echo "    @not_lan {" >> /etc/caddy/Caddyfile
+        echo "        not remote_ip private_ranges 127.0.0.1 ::1" >> /etc/caddy/Caddyfile
+        echo "    }" >> /etc/caddy/Caddyfile
+        echo "    abort @not_lan" >> /etc/caddy/Caddyfile
+        echo "    reverse_proxy http://osh-backend:8282 {" >> /etc/caddy/Caddyfile
+        echo "        flush_interval -1" >> /etc/caddy/Caddyfile
+        echo "    }" >> /etc/caddy/Caddyfile
+        echo "    tls /etc/caddy/certs/server.pem /etc/caddy/certs/server.key" >> /etc/caddy/Caddyfile
+        echo "}" >> /etc/caddy/Caddyfile
+        echo "$$TAILSCALE_DOMAIN {" >> /etc/caddy/Caddyfile
+        echo "    reverse_proxy http://osh-backend:8282 {" >> /etc/caddy/Caddyfile
+        echo "        flush_interval -1" >> /etc/caddy/Caddyfile
+        echo "    }" >> /etc/caddy/Caddyfile
+        echo "    tls {" >> /etc/caddy/Caddyfile
+        echo "        get_certificate tailscale" >> /etc/caddy/Caddyfile
+        echo "    }" >> /etc/caddy/Caddyfile
+        echo "}" >> /etc/caddy/Caddyfile
+        caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
+
+  osh-proxy-lan:
+    image: caddy:2.9.1
+    container_name: oscar-proxy-lan
+    profiles: ["lan-only"]
+    networks:
+      - osh-internal
+    ports:
+      - "80:80"
+      - "443:443"
+    depends_on:
+      osh-backend:
+        condition: service_healthy
+    environment:
+      - TAILSCALE_DOMAIN=${TAILSCALE_DOMAIN:-invalid.local}
+      - TAILSCALE_IP=${TAILSCALE_IP:-127.0.0.1}
+    volumes:
+      - caddy_data:/data
+      - caddy_config:/config
       - oscar_secrets:/etc/caddy/certs:ro
     restart: unless-stopped
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,7 +205,7 @@ services:
       - TS_SOCKS5_SERVER=:1055
       - TS_SOCKET=/var/run/tailscale/tailscaled.sock
     ports:
-      - "127.0.0.1:80:80"
+      - "80:80"
       - "443:443"
     volumes:
       - ./tailscale/state:/var/lib/tailscale
@@ -243,12 +243,20 @@ services:
       - /bin/sh
       - -c
       - |
-        echo "http://localhost {" > /etc/caddy/Caddyfile
+        echo ":80 {" > /etc/caddy/Caddyfile
+        echo "    @not_localhost {" >> /etc/caddy/Caddyfile
+        echo "        not remote_ip 127.0.0.1 ::1" >> /etc/caddy/Caddyfile
+        echo "    }" >> /etc/caddy/Caddyfile
+        echo "    abort @not_localhost" >> /etc/caddy/Caddyfile
         echo "    reverse_proxy http://osh-backend:8282 {" >> /etc/caddy/Caddyfile
         echo "        flush_interval -1" >> /etc/caddy/Caddyfile
         echo "    }" >> /etc/caddy/Caddyfile
         echo "}" >> /etc/caddy/Caddyfile
-        echo "https://localhost, 127.0.0.1 {" >> /etc/caddy/Caddyfile
+        echo ":443 {" >> /etc/caddy/Caddyfile
+        echo "    @not_lan {" >> /etc/caddy/Caddyfile
+        echo "        not remote_ip private_ranges 127.0.0.1 ::1" >> /etc/caddy/Caddyfile
+        echo "    }" >> /etc/caddy/Caddyfile
+        echo "    abort @not_lan" >> /etc/caddy/Caddyfile
         echo "    reverse_proxy http://osh-backend:8282 {" >> /etc/caddy/Caddyfile
         echo "        flush_interval -1" >> /etc/caddy/Caddyfile
         echo "    }" >> /etc/caddy/Caddyfile

--- a/docs/system_data_flow.svg
+++ b/docs/system_data_flow.svg
@@ -441,4 +441,31 @@
      d="m 650.30642,279.67448 h 17.41701 v 130.62926 h 17.41701"
      class="arrow"
      id="path54" />
+  <!-- Local LAN Client -->
+  <rect
+     x="690"
+     y="250"
+     width="160"
+     height="80"
+     rx="10"
+     class="ui"
+     id="rect_lan_client" />
+  <text
+     x="700"
+     y="275"
+     class="title"
+     id="text_lan_client">Local LAN Client</text>
+  <text
+     x="700"
+     y="295"
+     id="text_lan_client_2">Direct HTTPS (LAN)</text>
+  <text
+     x="700"
+     y="315"
+     id="text_lan_client_3">Auth: Local CA</text>
+  <!-- LAN Ingress to Proxy -->
+  <path
+     d="M 690,290 L 660,220"
+     class="arrow"
+     id="path_lan_ingress" />
 </svg>


### PR DESCRIPTION
Implemented a Hybrid Ingress architecture that allows secure HTTPS access over the Local Area Network (LAN) using a local CA fallback, while maintaining the primary Tailscale mesh. Restricted plain HTTP to localhost and enforced private IP range boundaries for the LAN HTTPS route. Included all mandatory documentation and diagram updates.

Fixes #136

---
*PR created automatically by Jules for task [10936131647415650753](https://jules.google.com/task/10936131647415650753) started by @tyronechrisharris*