### PR TITLE
Fix /sensorhub/admin/ca-cert endpoint to find CA correctly

### DIFF
--- a/include/osh-core/sensorhub-core/src/main/java/org/sensorhub/impl/service/HttpServer.java
+++ b/include/osh-core/sensorhub-core/src/main/java/org/sensorhub/impl/service/HttpServer.java
@@ -366,13 +366,27 @@ public class HttpServer extends AbstractModule<HttpServerConfig> implements IHtt
                 servletHandler.addServlet(new ServletHolder(new HttpServlet() {
                     @Override
                     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-                        File caFile = new File("root-ca.crt");
+                        String envCaPath = System.getenv("CA_CERT_PATH");
+                        File caFile = null;
+
+                        if (envCaPath != null && !envCaPath.trim().isEmpty()) {
+                            caFile = new File(envCaPath);
+                        }
+
+                        if (caFile == null || !caFile.exists()) {
+                            caFile = new File("/secrets/ca.pem");
+                            if (!caFile.exists()) {
+                                caFile = new File("root-ca.crt");
+                            }
+                        }
+
                         if (!caFile.exists()) {
                             resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Root CA not found");
                             return;
                         }
+
                         resp.setContentType("application/x-x509-ca-cert");
-                        resp.setHeader("Content-Disposition", "attachment; filename=\"root-ca.crt\"");
+                        resp.setHeader("Content-Disposition", "attachment; filename=\"" + caFile.getName() + "\"");
                         Files.copy(caFile.toPath(), resp.getOutputStream());
                     }
                 }), "/admin/ca-cert");


### PR DESCRIPTION
Fix /sensorhub/admin/ca-cert endpoint to find CA correctly

The `/sensorhub/admin/ca-cert` endpoint hardcoded the CA certificate path
to `root-ca.crt` in the current working directory. In the Dockerized
environment, the `init-secrets` container generates the CA certificate
at `/secrets/ca.pem`.

Updated the `HttpServer` to check the `CA_CERT_PATH` environment variable,
then default to `/secrets/ca.pem` and fall back to `root-ca.crt`.
Also dynamically sets the downloaded file name to match the file found.

---
*PR created automatically by Jules for task [11786895048919800161](https://jules.google.com/task/11786895048919800161) started by @tyronechrisharris*