### PR TITLE
Add mesh and lan-only launch scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,4 +221,9 @@ jobs:
             docker-compose.yml
             .env.example
             dist/release/launch-all.sh
+            dist/release/launch-all.bat
+            dist/release/launch-mesh.sh
+            dist/release/launch-mesh.bat
+            dist/release/launch-lan.sh
+            dist/release/launch-lan.bat
           prerelease: ${{ env.IS_PRERELEASE == 'true' }}

--- a/README.md
+++ b/README.md
@@ -76,12 +76,18 @@ OSCAR uses a dedicated Tailscale sidecar architecture to safely expose the proxy
 - Set your static `TAILSCALE_DOMAIN` (e.g., `oscar-server.tailxxxxx.ts.net`) in the `.env` file to enable automatic Let's Encrypt certificates.
 
 ### Launch the Stack
-The entire OSCAR stack (PostGIS, OSH Backend, Tailscale Sidecar, MediaMTX, and Caddy Reverse Proxy) is fully containerized. Ensure Docker is installed and run:
+The entire OSCAR stack (PostGIS, OSH Backend, Tailscale Sidecar, MediaMTX, and Caddy Reverse Proxy) is fully containerized. Ensure Docker is installed and run the command that fits your deployment topology:
 
+**To launch the full Tailscale Mesh configuration (default and recommended):**
 ```bash
-docker compose up -d
+COMPOSE_PROFILES=mesh docker compose up -d
 ```
-*Note for Offline Deployments: The legacy launch scripts (`launch-all.sh`, `launch-all.bat`, etc.) are still available inside the `dist/release/` directory of the zip archive for convenience.*
+
+**To launch the LAN-only configuration (no Tailscale sidecar):**
+```bash
+COMPOSE_PROFILES=lan-only docker compose up -d
+```
+*Note for Offline Deployments: The legacy launch scripts (`launch-mesh.sh`/`.bat`, `launch-lan.sh`/`.bat`, `launch-all.sh`/`.bat`, etc.) are still available inside the `dist/release/` directory of the zip archive for convenience.*
 
 ### Shutdown and Restart Procedures
 

--- a/dist/release/launch-lan.bat
+++ b/dist/release/launch-lan.bat
@@ -1,0 +1,20 @@
+@echo off
+setlocal enabledelayedexpansion
+
+where docker >nul 2>&1
+if %errorlevel% neq 0 (
+    echo ERROR: Docker is not installed or not in PATH.
+    cmd /c exit /b 1
+)
+
+echo Launching fully containerized OSCAR Stack via Docker Compose...
+set COMPOSE_PROFILES=lan-only
+docker compose up -d
+if %errorlevel% neq 0 (
+    echo ERROR: Docker Compose failed to start.
+    cmd /c exit /b 1
+)
+
+echo OSCAR Stack is launching. Please wait a few moments for the database and backend to initialize.
+echo Access the system at: http://localhost or https://localhost
+endlocal

--- a/dist/release/launch-lan.sh
+++ b/dist/release/launch-lan.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Ensure Docker is installed
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Error: Docker is not installed. Please install Docker first."
+    # Fail
+    sh -c "exit 1"
+fi
+
+# Optimize kernel parameters for high-density UDP camera streaming (Linux only)
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    echo "Optimizing kernel parameters for high-density UDP streaming..."
+    sudo sysctl -w net.core.rmem_max=26214400
+    sudo sysctl -w net.core.rmem_default=26214400
+    sudo sysctl -w net.core.wmem_max=26214400
+    sudo sysctl -w net.core.wmem_default=26214400
+    sudo sysctl -w fs.file-max=1000000
+fi
+
+# Pre-flight check: ensure hivemq-config directory and logback.xml exist
+# This prevents Docker from creating logback.xml as a directory during volume mount.
+if [ ! -d "hivemq-config" ]; then
+    echo "Creating hivemq-config directory..."
+    mkdir -p hivemq-config
+fi
+
+if [ ! -f "hivemq-config/logback.xml" ]; then
+    echo "Creating hivemq-config/logback.xml..."
+    cat << 'INNER_EOF' > hivemq-config/logback.xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- general logging in console -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{0} [%thread] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <!-- Suppress verbose auth/session debug logs -->
+    <logger name="org.sensorhub.impl.service.BridgedAuthenticator" level="WARN" />
+    <logger name="org.sensorhub.impl.service.OshLoginService" level="WARN" />
+
+</configuration>
+INNER_EOF
+fi
+
+# 1. Launch Docker Compose FIRST so the networks are actually created
+echo "Launching fully containerized OSCAR Stack via Docker Compose..."
+COMPOSE_PROFILES=lan-only docker compose up -d || exit 1
+
+# 2. Configure the firewall dynamically
+if [[ "$OSTYPE" == "linux-gnu"* ]] && command -v ufw >/dev/null 2>&1; then
+    echo "Configuring firewall for MediaMTX API access..."
+
+    # Dynamically find the exact network name attached to the backend container
+    NETWORK_NAME=$(docker inspect oscar-backend-container -f '{{range $k, $v := .NetworkSettings.Networks}}{{$k}}{{end}}' | tr -d '\r\n')
+
+    if [ -n "$NETWORK_NAME" ]; then
+        # Extract the subnet and aggressively strip any hidden Windows carriage returns
+        DOCKER_SUBNET=$(docker network inspect "$NETWORK_NAME" -f '{{(index .IPAM.Config 0).Subnet}}' | tr -d '\r\n')
+
+        if [ -n "$DOCKER_SUBNET" ]; then
+            echo "Whitelisting Docker subnet: $DOCKER_SUBNET"
+            sudo ufw allow from "$DOCKER_SUBNET" to any port 9997 proto tcp && sudo ufw allow from "$DOCKER_SUBNET" to any port 8554 proto tcp
+            sudo ufw reload
+        else
+            echo "Warning: Could not determine Docker subnet. Skipping UFW configuration."
+        fi
+    else
+        echo "Warning: Could not find backend container network. Skipping UFW configuration."
+    fi
+fi
+
+
+echo "OSCAR Stack is launching. Please wait a few moments for the database and backend to initialize."
+echo "Access the system at: http://localhost or https://localhost"

--- a/dist/release/launch-mesh.bat
+++ b/dist/release/launch-mesh.bat
@@ -1,0 +1,20 @@
+@echo off
+setlocal enabledelayedexpansion
+
+where docker >nul 2>&1
+if %errorlevel% neq 0 (
+    echo ERROR: Docker is not installed or not in PATH.
+    cmd /c exit /b 1
+)
+
+echo Launching fully containerized OSCAR Stack via Docker Compose...
+set COMPOSE_PROFILES=mesh
+docker compose up -d
+if %errorlevel% neq 0 (
+    echo ERROR: Docker Compose failed to start.
+    cmd /c exit /b 1
+)
+
+echo OSCAR Stack is launching. Please wait a few moments for the database and backend to initialize.
+echo Access the system at: http://localhost or https://localhost
+endlocal

--- a/dist/release/launch-mesh.sh
+++ b/dist/release/launch-mesh.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Ensure Docker is installed
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Error: Docker is not installed. Please install Docker first."
+    # Fail
+    sh -c "exit 1"
+fi
+
+# Optimize kernel parameters for high-density UDP camera streaming (Linux only)
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    echo "Optimizing kernel parameters for high-density UDP streaming..."
+    sudo sysctl -w net.core.rmem_max=26214400
+    sudo sysctl -w net.core.rmem_default=26214400
+    sudo sysctl -w net.core.wmem_max=26214400
+    sudo sysctl -w net.core.wmem_default=26214400
+    sudo sysctl -w fs.file-max=1000000
+fi
+
+# Pre-flight check: ensure hivemq-config directory and logback.xml exist
+# This prevents Docker from creating logback.xml as a directory during volume mount.
+if [ ! -d "hivemq-config" ]; then
+    echo "Creating hivemq-config directory..."
+    mkdir -p hivemq-config
+fi
+
+if [ ! -f "hivemq-config/logback.xml" ]; then
+    echo "Creating hivemq-config/logback.xml..."
+    cat << 'INNER_EOF' > hivemq-config/logback.xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- general logging in console -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{0} [%thread] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <!-- Suppress verbose auth/session debug logs -->
+    <logger name="org.sensorhub.impl.service.BridgedAuthenticator" level="WARN" />
+    <logger name="org.sensorhub.impl.service.OshLoginService" level="WARN" />
+
+</configuration>
+INNER_EOF
+fi
+
+# 1. Launch Docker Compose FIRST so the networks are actually created
+echo "Launching fully containerized OSCAR Stack via Docker Compose..."
+COMPOSE_PROFILES=mesh docker compose up -d || exit 1
+
+# 2. Configure the firewall dynamically
+if [[ "$OSTYPE" == "linux-gnu"* ]] && command -v ufw >/dev/null 2>&1; then
+    echo "Configuring firewall for MediaMTX API access..."
+
+    # Dynamically find the exact network name attached to the backend container
+    NETWORK_NAME=$(docker inspect oscar-backend-container -f '{{range $k, $v := .NetworkSettings.Networks}}{{$k}}{{end}}' | tr -d '\r\n')
+
+    if [ -n "$NETWORK_NAME" ]; then
+        # Extract the subnet and aggressively strip any hidden Windows carriage returns
+        DOCKER_SUBNET=$(docker network inspect "$NETWORK_NAME" -f '{{(index .IPAM.Config 0).Subnet}}' | tr -d '\r\n')
+
+        if [ -n "$DOCKER_SUBNET" ]; then
+            echo "Whitelisting Docker subnet: $DOCKER_SUBNET"
+            sudo ufw allow from "$DOCKER_SUBNET" to any port 9997 proto tcp && sudo ufw allow from "$DOCKER_SUBNET" to any port 8554 proto tcp
+            sudo ufw reload
+        else
+            echo "Warning: Could not determine Docker subnet. Skipping UFW configuration."
+        fi
+    else
+        echo "Warning: Could not find backend container network. Skipping UFW configuration."
+    fi
+fi
+
+
+echo "OSCAR Stack is launching. Please wait a few moments for the database and backend to initialize."
+echo "Access the system at: http://localhost or https://localhost"


### PR DESCRIPTION
This PR resolves the user request by introducing specific launch scripts (`launch-mesh.sh/.bat` and `launch-lan.sh/.bat`) for the `mesh` and `lan-only` Docker Compose profiles. The `README.md` has been updated to reflect the new launch procedures and reference these new legacy offline script options. Tests have been run and verified.

---
*PR created automatically by Jules for task [170060573157222432](https://jules.google.com/task/170060573157222432) started by @tyronechrisharris*