### PR TITLE
Update log level to default to error across the system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 # OSCAR Node Deployment Environment Variables
 
 # ==============================================================================
+# ==============================================================================
+# Stack Logging Configuration
+# Global logging level for all services: error, warn, info, debug, trace
+# ==============================================================================
+LOG_LEVEL=error
+
 # OSCAR Image Version
 # By default, Docker Compose will pull the 'latest' stable production release.
 # If you are testing a specific PR build, uncomment the line below and set the PR tag.

--- a/dist/config/standard/logback.xml
+++ b/dist/config/standard/logback.xml
@@ -23,19 +23,19 @@
         </encoder>
     </appender>
 
-    <root level="info">
+    <root level="${LOG_LEVEL:-error}">
         <appender-ref ref="STDOUT" />
     </root>
 
-    <logger name="org.sensorhub" level="info">
+    <logger name="org.sensorhub" level="${LOG_LEVEL:-error}">
         <appender-ref ref="MODULE_FILE" />
     </logger>
 
     <!-- Suppress verbose auth/session debug logs -->
-    <logger name="org.sensorhub.impl.service.BridgedAuthenticator" level="info" />
-    <logger name="org.sensorhub.impl.service.OshLoginService" level="info" />
+    <logger name="org.sensorhub.impl.service.BridgedAuthenticator" level="${LOG_LEVEL:-error}" />
+    <logger name="org.sensorhub.impl.service.OshLoginService" level="${LOG_LEVEL:-error}" />
 
-    <logger name="org.eclipse.jetty" level="warn" />
-    <logger name="org.vast" level="warn"/>
+    <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}" />
+    <logger name="org.vast" level="${LOG_LEVEL:-error}"/>
 
 </configuration>

--- a/dist/release/launch-all.sh
+++ b/dist/release/launch-all.sh
@@ -37,13 +37,13 @@ if [ ! -f "hivemq-config/logback.xml" ]; then
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="${LOG_LEVEL:-error}">
         <appender-ref ref="STDOUT" />
     </root>
 
     <!-- Suppress verbose auth/session debug logs -->
-    <logger name="org.sensorhub.impl.service.BridgedAuthenticator" level="WARN" />
-    <logger name="org.sensorhub.impl.service.OshLoginService" level="WARN" />
+    <logger name="org.sensorhub.impl.service.BridgedAuthenticator" level="${LOG_LEVEL:-error}" />
+    <logger name="org.sensorhub.impl.service.OshLoginService" level="${LOG_LEVEL:-error}" />
 
 </configuration>
 INNER_EOF

--- a/dist/release/launch-lan.sh
+++ b/dist/release/launch-lan.sh
@@ -37,13 +37,13 @@ if [ ! -f "hivemq-config/logback.xml" ]; then
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="${LOG_LEVEL:-error}">
         <appender-ref ref="STDOUT" />
     </root>
 
     <!-- Suppress verbose auth/session debug logs -->
-    <logger name="org.sensorhub.impl.service.BridgedAuthenticator" level="WARN" />
-    <logger name="org.sensorhub.impl.service.OshLoginService" level="WARN" />
+    <logger name="org.sensorhub.impl.service.BridgedAuthenticator" level="${LOG_LEVEL:-error}" />
+    <logger name="org.sensorhub.impl.service.OshLoginService" level="${LOG_LEVEL:-error}" />
 
 </configuration>
 INNER_EOF

--- a/dist/release/launch-mesh.sh
+++ b/dist/release/launch-mesh.sh
@@ -37,13 +37,13 @@ if [ ! -f "hivemq-config/logback.xml" ]; then
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="${LOG_LEVEL:-error}">
         <appender-ref ref="STDOUT" />
     </root>
 
     <!-- Suppress verbose auth/session debug logs -->
-    <logger name="org.sensorhub.impl.service.BridgedAuthenticator" level="WARN" />
-    <logger name="org.sensorhub.impl.service.OshLoginService" level="WARN" />
+    <logger name="org.sensorhub.impl.service.BridgedAuthenticator" level="${LOG_LEVEL:-error}" />
+    <logger name="org.sensorhub.impl.service.OshLoginService" level="${LOG_LEVEL:-error}" />
 
 </configuration>
 INNER_EOF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   init-secrets:
     image: eclipse-temurin:21.0.6_7-jre-alpine
     container_name: oscar-init-secrets
+    environment:
+      - LOG_LEVEL=${LOG_LEVEL:-error}
     volumes:
       - oscar_secrets:/secrets
       - mtx_secrets:/mtx-secrets
@@ -50,6 +52,7 @@ services:
         echo $$USER > /mtx-secrets/.mediamtx_api_user;
 
         echo "# MediaMTX Configuration for OSCAR (Auto-Generated)" > /mtx-secrets/mediamtx.yml;
+        echo "logLevel: $${LOG_LEVEL:-error}" >> /mtx-secrets/mediamtx.yml;
         echo "api: true" >> /mtx-secrets/mediamtx.yml;
         echo "apiAddress: :9997" >> /mtx-secrets/mediamtx.yml;
         echo "writeQueueSize: 1024" >> /mtx-secrets/mediamtx.yml;
@@ -96,6 +99,8 @@ services:
       - "ssl_cert_file=/secrets/db-server.crt"
       - "-c"
       - "ssl_key_file=/secrets/db-server.key"
+      - "-c"
+      - "log_min_messages=${LOG_LEVEL:-error}"
     environment:
       - POSTGRES_DB=gis
       - POSTGRES_USER=postgres
@@ -150,7 +155,7 @@ services:
       - MEDIAMTX_API_USER_FILE=/mtx_secrets/.mediamtx_api_user
       - MEDIAMTX_API_PASS_FILE=/mtx_secrets/.mediamtx_api_pass
       - MEDIAMTX_IP=${MEDIAMTX_IP:-host.docker.internal}
-      - JAVA_OPTS=-Xmx${BACKEND_JVM_HEAP:-2G} -Xms${BACKEND_JVM_HEAP:-2G} ${PROXY_OPTS:-} -DsocksNonProxyHosts=localhost|127.*|10.*|172.*|192.168.*|host.docker.internal -Dhttp.nonProxyHosts=localhost|127.*|10.*|172.*|192.168.*|host.docker.internal
+      - JAVA_OPTS=-Xmx${BACKEND_JVM_HEAP:-2G} -Xms${BACKEND_JVM_HEAP:-2G} ${PROXY_OPTS:-} -DLOG_LEVEL=${LOG_LEVEL:-error} -DsocksNonProxyHosts=localhost|127.*|10.*|172.*|192.168.*|host.docker.internal -Dhttp.nonProxyHosts=localhost|127.*|10.*|172.*|192.168.*|host.docker.internal
     volumes:
       - ./osh-node-oscar/config:/app/config
       - ./osh-node-oscar/db:/app/db
@@ -232,6 +237,7 @@ services:
     environment:
       - TAILSCALE_DOMAIN=${TAILSCALE_DOMAIN:-invalid.local}
       - TAILSCALE_IP=${TAILSCALE_IP:-127.0.0.1}
+      - LOG_LEVEL=${LOG_LEVEL:-error}
     volumes:
       - caddy_data:/data
       - caddy_config:/config
@@ -246,7 +252,12 @@ services:
       - /bin/sh
       - -c
       - |
-        echo ":80 {" > /etc/caddy/Caddyfile
+        echo "{" > /etc/caddy/Caddyfile
+        echo "    log {" >> /etc/caddy/Caddyfile
+        echo "        level $$LOG_LEVEL" >> /etc/caddy/Caddyfile
+        echo "    }" >> /etc/caddy/Caddyfile
+        echo "}" >> /etc/caddy/Caddyfile
+        echo ":80 {" >> /etc/caddy/Caddyfile
         echo "    @not_lan {" >> /etc/caddy/Caddyfile
         echo "        not remote_ip private_ranges 127.0.0.1 ::1" >> /etc/caddy/Caddyfile
         echo "    }" >> /etc/caddy/Caddyfile
@@ -291,6 +302,7 @@ services:
     environment:
       - TAILSCALE_DOMAIN=${TAILSCALE_DOMAIN:-invalid.local}
       - TAILSCALE_IP=${TAILSCALE_IP:-127.0.0.1}
+      - LOG_LEVEL=${LOG_LEVEL:-error}
     volumes:
       - caddy_data:/data
       - caddy_config:/config
@@ -304,7 +316,12 @@ services:
       - /bin/sh
       - -c
       - |
-        echo ":80 {" > /etc/caddy/Caddyfile
+        echo "{" > /etc/caddy/Caddyfile
+        echo "    log {" >> /etc/caddy/Caddyfile
+        echo "        level $$LOG_LEVEL" >> /etc/caddy/Caddyfile
+        echo "    }" >> /etc/caddy/Caddyfile
+        echo "}" >> /etc/caddy/Caddyfile
+        echo ":80 {" >> /etc/caddy/Caddyfile
         echo "    @not_lan {" >> /etc/caddy/Caddyfile
         echo "        not remote_ip private_ranges 127.0.0.1 ::1" >> /etc/caddy/Caddyfile
         echo "    }" >> /etc/caddy/Caddyfile

--- a/hivemq-config/logback.xml
+++ b/hivemq-config/logback.xml
@@ -8,12 +8,12 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="${LOG_LEVEL:-error}">
         <appender-ref ref="STDOUT" />
     </root>
 
     <!-- Suppress verbose auth/session debug logs -->
-    <logger name="org.sensorhub.impl.service.BridgedAuthenticator" level="WARN" />
-    <logger name="org.sensorhub.impl.service.OshLoginService" level="WARN" />
+    <logger name="org.sensorhub.impl.service.BridgedAuthenticator" level="${LOG_LEVEL:-error}" />
+    <logger name="org.sensorhub.impl.service.OshLoginService" level="${LOG_LEVEL:-error}" />
 
 </configuration>

--- a/include/osh-addons/comm/sensorhub-comm-ble-dbus/src/test/resources/logback-test.xml
+++ b/include/osh-addons/comm/sensorhub-comm-ble-dbus/src/test/resources/logback-test.xml
@@ -5,11 +5,11 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{0} - %msg%n</pattern>
     </encoder>
   </appender>
-  <logger name="org.eclipse.jetty" level="warn"/>
-  <logger name="org.sensorhub" level="debug"/>
-  <logger name="org.vast" level="debug"/>
-  <logger name="org.eclipse.kura" level="debug"/>
-  <root level="WARN">          
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.vast" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.eclipse.kura" level="${LOG_LEVEL:-error}"/>
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>    
 </configuration>

--- a/include/osh-addons/dist/osh-base/config/logback.xml
+++ b/include/osh-addons/dist/osh-base/config/logback.xml
@@ -23,13 +23,13 @@
     </encoder>
   </appender>
   
-  <root level="warn">
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>
-  <logger name="org.sensorhub" level="info">
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}">
     <appender-ref ref="MODULE_FILE" />
   </logger>
-  <logger name="org.eclipse.jetty" level="warn" />
-  <logger name="org.vast" level="warn"/>
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}" />
+  <logger name="org.vast" level="${LOG_LEVEL:-error}"/>
   
 </configuration>

--- a/include/osh-addons/dist/osh-rpi-geocam/src/config/logback.xml
+++ b/include/osh-addons/dist/osh-rpi-geocam/src/config/logback.xml
@@ -23,14 +23,14 @@
     </encoder>
   </appender>
   
-  <root level="warn">
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>
-  <logger name="org.sensorhub" level="debug">
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}">
     <appender-ref ref="MODULE_FILE" />
   </logger>
-  <logger name="org.sensorhub.impl.sensor.bno055" level="trace"/>
-  <logger name="org.eclipse.jetty" level="warn" />
-  <logger name="org.vast" level="warn"/>
+  <logger name="org.sensorhub.impl.sensor.bno055" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}" />
+  <logger name="org.vast" level="${LOG_LEVEL:-error}"/>
   
 </configuration>

--- a/include/osh-addons/dist/osh-sensiasoft/config/logback.xml
+++ b/include/osh-addons/dist/osh-sensiasoft/config/logback.xml
@@ -23,13 +23,13 @@
     </encoder>
   </appender>
   
-  <root level="warn">
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>
-  <logger name="org.sensorhub" level="debug">
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}">
     <appender-ref ref="MODULE_FILE" />
   </logger>
-  <logger name="org.eclipse.jetty" level="warn" />
-  <logger name="org.vast" level="warn"/>
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}" />
+  <logger name="org.vast" level="${LOG_LEVEL:-error}"/>
   
 </configuration>

--- a/include/osh-addons/sensors/avl/sensorhub-driver-avl-911/src/test/resources/logback-test.xml
+++ b/include/osh-addons/sensors/avl/sensorhub-driver-avl-911/src/test/resources/logback-test.xml
@@ -5,10 +5,10 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{0} - %msg%n</pattern>
     </encoder>
   </appender>
-  <logger name="org.eclipse.jetty" level="warn"/>
-  <logger name="org.sensorhub" level="debug"/>
-  <logger name="org.vast" level="debug"/>
-  <root level="WARN">          
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.vast" level="${LOG_LEVEL:-error}"/>
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>    
 </configuration>

--- a/include/osh-addons/sensors/health/sensorhub-driver-angelsensor/src/test/resources/logback-test.xml
+++ b/include/osh-addons/sensors/health/sensorhub-driver-angelsensor/src/test/resources/logback-test.xml
@@ -5,9 +5,9 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{0} - %msg%n</pattern>
     </encoder>
   </appender>
-  <logger name="org.eclipse.jetty" level="warn"/>
-  <logger name="org.sensorhub" level="debug"/>
-  <root level="INFO">          
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}"/>
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>    
 </configuration>

--- a/include/osh-addons/sensors/positioning/sensorhub-driver-bno055/src/test/resources/logback-test.xml
+++ b/include/osh-addons/sensors/positioning/sensorhub-driver-bno055/src/test/resources/logback-test.xml
@@ -5,9 +5,9 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{0} - %msg%n</pattern>
     </encoder>
   </appender>
-  <logger name="org.eclipse.jetty" level="warn"/>
-  <logger name="org.sensorhub" level="debug"/>
-  <root level="INFO">          
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}"/>
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>    
 </configuration>

--- a/include/osh-addons/sensors/positioning/sensorhub-driver-gps-nmea/src/test/resources/logback-test.xml
+++ b/include/osh-addons/sensors/positioning/sensorhub-driver-gps-nmea/src/test/resources/logback-test.xml
@@ -5,10 +5,10 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{0} - %msg%n</pattern>
     </encoder>
   </appender>
-  <logger name="org.eclipse.jetty" level="warn"/>
-  <logger name="org.sensorhub" level="debug"/>
-  <logger name="org.vast" level="debug"/>
-  <root level="WARN">          
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.vast" level="${LOG_LEVEL:-error}"/>
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>    
 </configuration>

--- a/include/osh-addons/sensors/positioning/sensorhub-driver-mti/src/test/resources/logback-test.xml
+++ b/include/osh-addons/sensors/positioning/sensorhub-driver-mti/src/test/resources/logback-test.xml
@@ -5,9 +5,9 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{0} - %msg%n</pattern>
     </encoder>
   </appender>
-  <logger name="org.eclipse.jetty" level="warn"/>
-  <logger name="org.sensorhub" level="debug"/>
-  <root level="INFO">          
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}"/>
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>    
 </configuration>

--- a/include/osh-addons/sensors/robotics/sensorhub-driver-mavlink/src/test/resources/logback-test.xml
+++ b/include/osh-addons/sensors/robotics/sensorhub-driver-mavlink/src/test/resources/logback-test.xml
@@ -5,11 +5,11 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{0} - %msg%n</pattern>
     </encoder>
   </appender>
-  <logger name="org.eclipse.jetty" level="warn"/>
-  <logger name="org.sensorhub" level="debug"/>
-  <logger name="org.sensorhub.impl.sensor.mavlink" level="trace"/>
-  <logger name="org.vast" level="debug"/>
-  <root level="WARN">          
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub.impl.sensor.mavlink" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.vast" level="${LOG_LEVEL:-error}"/>
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>    
 </configuration>

--- a/include/osh-addons/sensors/robotics/sensorhub-driver-pwm-servos/src/test/resources/logback-test.xml
+++ b/include/osh-addons/sensors/robotics/sensorhub-driver-pwm-servos/src/test/resources/logback-test.xml
@@ -5,10 +5,10 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{0} - %msg%n</pattern>
     </encoder>
   </appender>
-  <logger name="org.eclipse.jetty" level="warn"/>
-  <logger name="org.sensorhub" level="debug"/>
-  <logger name="org.vast" level="debug"/>
-  <root level="WARN">          
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.vast" level="${LOG_LEVEL:-error}"/>
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>    
 </configuration>

--- a/include/osh-addons/sensors/simulated/sensorhub-driver-plume/src/test/resources/logback-test.xml
+++ b/include/osh-addons/sensors/simulated/sensorhub-driver-plume/src/test/resources/logback-test.xml
@@ -5,9 +5,9 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{0} - %msg%n</pattern>
     </encoder>
   </appender>
-  <logger name="org.eclipse.jetty" level="warn"/>
-  <logger name="org.sensorhub" level="debug"/>
-  <root level="INFO">          
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}"/>
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>    
 </configuration>

--- a/include/osh-addons/sensors/video/sensorhub-driver-rtpcam/src/test/resources/logback-test.xml
+++ b/include/osh-addons/sensors/video/sensorhub-driver-rtpcam/src/test/resources/logback-test.xml
@@ -5,11 +5,11 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{0} - %msg%n</pattern>
     </encoder>
   </appender>
-  <logger name="org.eclipse.jetty" level="warn"/>
-  <logger name="org.sensorhub" level="debug"/>
-  <logger name="org.sensorhub.impl.sensor.rtpcam" level="trace"/>
-  <logger name="org.sensorhub.impl.sensor.rtpcam.RTCPSender" level="trace"/>
-  <root level="INFO">          
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub.impl.sensor.rtpcam" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub.impl.sensor.rtpcam.RTCPSender" level="${LOG_LEVEL:-error}"/>
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>    
 </configuration>

--- a/include/osh-addons/sensors/video/sensorhub-driver-v4l/src/test/resources/logback-test.xml
+++ b/include/osh-addons/sensors/video/sensorhub-driver-v4l/src/test/resources/logback-test.xml
@@ -5,9 +5,9 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{0} - %msg%n</pattern>
     </encoder>
   </appender>
-  <logger name="org.eclipse.jetty" level="warn"/>
-  <logger name="org.sensorhub" level="debug"/>
-  <root level="INFO">          
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}"/>
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>    
 </configuration>

--- a/include/osh-addons/sensors/video/sensorhub-driver-virb-xe/src/test/resources/logback-test.xml
+++ b/include/osh-addons/sensors/video/sensorhub-driver-virb-xe/src/test/resources/logback-test.xml
@@ -5,9 +5,9 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{0} - %msg%n</pattern>
     </encoder>
   </appender>
-  <logger name="org.eclipse.jetty" level="warn"/>
-  <logger name="org.sensorhub" level="debug"/>
-  <root level="INFO">          
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}"/>
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>    
 </configuration>

--- a/include/osh-addons/test/sensorhub-test/src/main/resources/logback-test.xml
+++ b/include/osh-addons/test/sensorhub-test/src/main/resources/logback-test.xml
@@ -23,18 +23,18 @@
     </encoder>
   </appender>
   
-  <root level="warn">
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>
-  <logger name="org.sensorhub" level="debug">
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}">
     <appender-ref ref="MODULE_FILE" />
   </logger>
-  <logger name="com.delta" level="debug">
+  <logger name="com.delta" level="${LOG_LEVEL:-error}">
     <appender-ref ref="MODULE_FILE" />
   </logger>
-  <logger name="org.eclipse.jetty" level="warn" />
-  <logger name="org.eclipse.kura" level="debug" />
-  <logger name="org.vast" level="warn"/>
-  <logger name="org.sensorhub.impl.serialization.kryo" level="debug"/>
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}" />
+  <logger name="org.eclipse.kura" level="${LOG_LEVEL:-error}" />
+  <logger name="org.vast" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub.impl.serialization.kryo" level="${LOG_LEVEL:-error}"/>
   
 </configuration>

--- a/include/osh-core/dist/main/logback.xml
+++ b/include/osh-core/dist/main/logback.xml
@@ -23,13 +23,13 @@
     </encoder>
   </appender>
   
-  <root level="info">
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>
-  <logger name="org.sensorhub" level="info">
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}">
     <appender-ref ref="MODULE_FILE" />
   </logger>
-  <logger name="org.eclipse.jetty" level="warn" />
-  <logger name="org.vast" level="warn"/>
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}" />
+  <logger name="org.vast" level="${LOG_LEVEL:-error}"/>
   
 </configuration>

--- a/include/osh-core/dist/osgi/logback.xml
+++ b/include/osh-core/dist/osgi/logback.xml
@@ -23,13 +23,13 @@
     </encoder>
   </appender>
   
-  <root level="warn">
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>
-  <logger name="org.sensorhub" level="info">
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}">
     <appender-ref ref="MODULE_FILE" />
   </logger>
-  <logger name="org.eclipse.jetty" level="warn" />
-  <logger name="org.vast" level="warn"/>
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}" />
+  <logger name="org.vast" level="${LOG_LEVEL:-error}"/>
   
 </configuration>

--- a/include/osh-core/sensorhub-core-osgi/src/main/resources/logback.xml
+++ b/include/osh-core/sensorhub-core-osgi/src/main/resources/logback.xml
@@ -5,9 +5,9 @@
       <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{0} - %msg%n</pattern>
     </encoder>
   </appender>
-  <logger name="org.eclipse.jetty" level="warn"/>
-  <logger name="org.sensorhub" level="debug"/>
-  <root level="warn">
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}"/>
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>    
 </configuration>

--- a/include/osh-core/sensorhub-core-osgi/src/test/resources/logback-test.xml
+++ b/include/osh-core/sensorhub-core-osgi/src/test/resources/logback-test.xml
@@ -5,9 +5,9 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{0} - %msg%n</pattern>
     </encoder>
   </appender>
-  <logger name="org.eclipse.jetty" level="warn"/>
-  <logger name="org.sensorhub" level="debug"/>
-  <root level="INFO">          
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}"/>
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>    
 </configuration>

--- a/include/osh-core/sensorhub-core/src/main/resources/logback.xml
+++ b/include/osh-core/sensorhub-core/src/main/resources/logback.xml
@@ -5,9 +5,9 @@
       <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{0} - %msg%n</pattern>
     </encoder>
   </appender>
-  <logger name="org.eclipse.jetty" level="warn"/>
-  <logger name="org.sensorhub" level="info"/>
-  <root level="warn">          
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}"/>
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>    
 </configuration>

--- a/include/osh-core/sensorhub-core/src/test/resources/logback-test.xml
+++ b/include/osh-core/sensorhub-core/src/test/resources/logback-test.xml
@@ -5,9 +5,9 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{0} - %msg%n</pattern>
     </encoder>
   </appender>
-  <logger name="org.eclipse.jetty" level="warn"/>
-  <logger name="org.sensorhub" level="debug"/>
-  <root level="INFO">          
+  <logger name="org.eclipse.jetty" level="${LOG_LEVEL:-error}"/>
+  <logger name="org.sensorhub" level="${LOG_LEVEL:-error}"/>
+  <root level="${LOG_LEVEL:-error}">
     <appender-ref ref="STDOUT" />
   </root>    
 </configuration>


### PR DESCRIPTION
Update log level to default to error across the system\n\n- Added LOG_LEVEL to .env.example\n- Updated docker-compose.yml to pass LOG_LEVEL to init-secrets, osh-postgis, osh-backend, and caddy proxies.\n- Replaced hardcoded info/debug/warn log levels with ${LOG_LEVEL:-error} in logback files.

---
*PR created automatically by Jules for task [1702028464812993131](https://jules.google.com/task/1702028464812993131) started by @tyronechrisharris*